### PR TITLE
Switch to valid version of Minecraft 1.5

### DIFF
--- a/modules/v1_5_R1/pom.xml
+++ b/modules/v1_5_R1/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.5.0-R0.1</version>
+            <version>1.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Looking at craftbukkit commit [83d29e461c](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/83d29e461c), it appears that the correct version is 1.5-R0.1-SNAPSHOT. A quick look at the craftbukkit versions available in [md-5 repo])(http://repo.md-5.net/content/groups/public/org/bukkit/craftbukkit/) confirms it.